### PR TITLE
fixed error

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -31,7 +31,7 @@ function handleConfigChange(){
         if(codes.indexOf(item) === -1){
             statusBarItems[item].hide();
             statusBarItems[item].dispose();
-            statusBarItems[item] = false;
+            delete statusBarItems[item];
         }
     });
     init();


### PR DESCRIPTION
如果设置中更改或者删除了股票代码，是将原来的股票代码的key删除掉，而不是设置为false。
设置为false的话，在删除和切换代码的时候会报错。
![image](https://user-images.githubusercontent.com/12585605/53947018-e5ef1580-40ff-11e9-8341-ef602d86bab1.png)
